### PR TITLE
Fix indenting for local .pipenv-cache volume

### DIFF
--- a/example2/batect.yml
+++ b/example2/batect.yml
@@ -8,8 +8,8 @@ containers:
       - local: .pip-cache
         container: /src/.pip-cache
         options: cached
-        - local: .pipenv-cache
-          container: /src/.pipenv-cache
+      - local: .pipenv-cache
+        container: /src/.pipenv-cache
     working_directory: /src
     environment:
       PYTHONPATH: "/src"


### PR DESCRIPTION
Otherwise it's not correct yaml, and we receive the error message:
```sh
➜  example2 git:(master) ./batect --list-tasks
/home/janek/Experiments/batect-build-and-test-environments-as-code-with-a-python-sample-project-47903d7cded8/batect-sample-python/example2/batect.yml (line 11, column 9): while parsing a block mapping
 at line 8, column 9:
          - local: .pip-cache
            ^
expected <block end>, but found '-'
 at line 11, column 9:
            - local: .pipenv-cache
            ^
```